### PR TITLE
python3 - fix #38

### DIFF
--- a/Asserlang_Interactive_Python3/main.py
+++ b/Asserlang_Interactive_Python3/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from typing import Dict, Optional, Union, List
+from xml.dom import ValidationErr
 
 
 def end_letter(word: str, yes: Optional[str] = "은", no: Optional[str] = "는") -> str:
@@ -92,7 +93,12 @@ class asserlang:
                         break
                 else:
                     if i.startswith("ㅇㅉ"):
-                        result[index] += int(input("입력: "))
+                        try:
+                            _input = int(input("입력: "))
+                            result[index] += _input
+                        except ValueError:
+                            self.error("어쩔변수: 문자열은 입력받을 수 없음.")
+                            return(None)
                         j = "ㅇㅉ"
                     else:
                         self.error("어쩔변수: 해당하는 변수가 없음")


### PR DESCRIPTION
python3 구현체에서 ㅌㅂ에 문자열이 들어올 시 튕기던 문제 해결.
하지만,
```
쿠쿠루삥뽕
어쩔티비~ㅌㅂ
ㅇㅉ티비
쿠쿠루삥뽕
```
이 있을때, ㅌㅂ에 문자열을 입력하면,
```
어쩔변수: "티비"는 선언되지 않음
```
에러가 발생하는 문제가 있음.
에러가 발생할 경우 다시 인풋을 받는것도 좋을 것 같은.